### PR TITLE
migrated to CFEP-25

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,20 @@ source:
   sha256: f196666ff22c97e51068c36393d447d259bd067dd22b3e22393ab61e5892a855
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python {{ python_min }}
     - setuptools
   run:
     - matplotlib-base
     - numkit
     - numpy >=1.0
-    - python >=3.9
+    - python >={{ python_min }}
 
 test:
   imports:
@@ -34,6 +34,7 @@ test:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/Becksteinlab/GromacsWrapper


### PR DESCRIPTION
- update meta.yml
- do not pin python_min because gromacswrapper supports the conda-forge minimum of 3.9